### PR TITLE
Build log window clears instead of reopening.

### DIFF
--- a/scripts/mgear/shifter/__init__.py
+++ b/scripts/mgear/shifter/__init__.py
@@ -35,14 +35,22 @@ SHIFTER_COMPONENT_ENV_KEY = "MGEAR_SHIFTER_COMPONENT_PATH"
 
 
 def log_window():
-    logWin = pm.window(title="Shifter Build Log", iconName='Shifter Log')
-    pm.columnLayout(adjustableColumn=True)
-    pm.cmdScrollFieldReporter(width=800, height=500, clr=True)
-    pm.button(label='Close', command=(
-        'import pymel.core as pm\npm.deleteUI(\"' + logWin +
-        '\", window=True)'))
-    pm.setParent('..')
-    pm.showWindow(logWin)
+    log_window_name = "mgear_shifter_build_log_window"
+    log_window_field_reporter = "mgear_shifter_log_field_reporter"
+    if not pm.window(log_window_name, exists=True):
+        logWin = pm.window(log_window_name, title="Shifter Build Log",
+                           iconName='Shifter Log')
+        pm.columnLayout(adjustableColumn=True)
+        pm.cmdScrollFieldReporter(log_window_field_reporter,
+                                  width=800, height=500, clr=True)
+        pm.button(label='Close', command=(
+            'import pymel.core as pm\npm.deleteUI(\"' + logWin +
+            '\", window=True)'))
+        pm.setParent('..')
+        pm.showWindow(logWin)
+    else:
+        pm.cmdScrollFieldReporter(log_window_field_reporter, e=True, clr=True)
+        pm.showWindow(log_window_name)
     mgear.logInfos()
 
 


### PR DESCRIPTION
It's a small improvement.
Sometimes the build log opens but stays blank until the build is complete.
Shifter will keep opening new windows every time you build.

This checks if there is an existing build log and clears it instead of creating a new one.